### PR TITLE
SelectSearchablePage: missing impl. AfterViewInit

### DIFF
--- a/src/components/select-searchable/select-searchable-page.ts
+++ b/src/components/select-searchable/select-searchable-page.ts
@@ -1,4 +1,4 @@
-import { Component, ViewChild } from '@angular/core';
+import { Component, ViewChild, AfterViewInit } from '@angular/core';
 import { NavParams, NavController, Searchbar, InfiniteScroll } from 'ionic-angular';
 import { SelectSearchable } from './select-searchable';
 
@@ -11,7 +11,7 @@ import { SelectSearchable } from './select-searchable';
         '[class.select-searchable-page-multiple]': 'selectComponent.multiple'
     }
 })
-export class SelectSearchablePage {
+export class SelectSearchablePage implements AfterViewInit {
     selectComponent: SelectSearchable;
     filteredItems: any[];
     selectedItems: any[] = [];


### PR DESCRIPTION
In SelectSearchablePage there is ngAfterViewInit() method, but declaration "implements AfterViewInit" is missing.