### PR TITLE
Fixing wrong searchPlaceholder default value

### DIFF
--- a/README.md
+++ b/README.md
@@ -200,7 +200,7 @@ A placeholder for Searchbar.
 `String`  
 
 ### Default value
-`null`
+A text string `Search`.
 
 ## Events
 

--- a/src/components/select-searchable/select-searchable.ts
+++ b/src/components/select-searchable/select-searchable.ts
@@ -43,7 +43,7 @@ export class SelectSearchable implements ControlValueAccessor, OnDestroy, OnChan
     @Input() canReset = false;
     @Input() hasInfiniteScroll = false;
     @Input() title: string;
-    @Input() searchPlaceholder: string = 'Enter 3 or more characters';
+    @Input() searchPlaceholder: string;
     @Output() onChange: EventEmitter<any> = new EventEmitter();
     @Output() onSearch: EventEmitter<any> = new EventEmitter();
     @Output() onInfiniteScroll: EventEmitter<any> = new EventEmitter();


### PR DESCRIPTION
In SelectSearchable class, there is (was) default value:
`searchPlaceholder: string = 'Enter 3 or more characters';`

And in select-searchable-page.html there is default value
` [placeholder]="selectComponent.searchPlaceholder || 'Search'">`

First one is wrong because filtering begins immediately after one character. 
So I deleted searchPlaceholder variable initialization, default will be **Search** and I also updated documentation in Readme.md.